### PR TITLE
add: APIから都道府県一覧のデータを取得する。

### DIFF
--- a/src/app/api/page.tsx
+++ b/src/app/api/page.tsx
@@ -1,0 +1,6 @@
+import { getPrefectures } from "@/lib/getPrefectures";
+
+export default async function Page() {
+    const data = await getPrefectures();
+    console.log(data);
+}

--- a/src/lib/getPrefectures.ts
+++ b/src/lib/getPrefectures.ts
@@ -1,0 +1,15 @@
+export async function getPrefectures() {
+    try {
+        const response = await fetch(String(process.env.NEXT_PUBLIC_API_URL)+ '/api/v1/prefectures', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json; charset=UTF-8',
+                'X-API-KEY': String(process.env.NEXT_PUBLIC_API_KEY),
+                cache: 'force-cache'
+            }
+        }).then((res) => res.json());
+        return response;
+    } catch (error ) {
+        console.error('Error:', error);
+    }
+}

--- a/src/lib/getPrefectures.ts
+++ b/src/lib/getPrefectures.ts
@@ -1,6 +1,8 @@
+import { PrefecturesResponse } from "@/types/prefectures/prefectures";
+
 export async function getPrefectures() {
     try {
-        const response = await fetch(String(process.env.NEXT_PUBLIC_API_URL)+ '/api/v1/prefectures', {
+        const response: Promise<PrefecturesResponse> = await fetch(String(process.env.NEXT_PUBLIC_API_URL)+ '/api/v1/prefectures', {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json; charset=UTF-8',

--- a/src/types/prefectures/prefectures.ts
+++ b/src/types/prefectures/prefectures.ts
@@ -1,0 +1,9 @@
+export interface Prefectures {
+    prefCode: number;
+    prefName: string;
+}
+
+export interface PrefecturesResponse {
+    massage: null;
+    result: Prefectures[];
+}


### PR DESCRIPTION
## 概要

チェックボックスで表示するために、課題のAPIから都道府県一覧のデータを取得する。
また、都道府県の型を定義した。

## 変更点

- [`src/lib/getPrefectures.ts`] APIで都道府県一覧のデータ一を取得する関数を追加
- [`src/types/prefectures/prefectures.ts`] 都道府県一覧の型を追加
- [`src/app/api/page.tsx`] API確認用のページを作成。

## 影響範囲


## 関連Issue
- 関連Issue: #1 
- 関連Issue: #2 